### PR TITLE
Fix typo in definition.py

### DIFF
--- a/kitty/options/definition.py
+++ b/kitty/options/definition.py
@@ -296,7 +296,7 @@ opt('cursor', '#cccccc',
     option_type='to_color_or_none',
     long_text='''
 Default cursor color. If set to the special value :code:`none` the cursor will
-be rendered with a "reverse video" effect. It's color will be the color of the
+be rendered with a "reverse video" effect. Its color will be the color of the
 text in the cell it is over and the text will be rendered with the background
 color of the cell. Note that if the program running in the terminal sets a
 cursor color, this takes precedence. Also, the cursor colors are modified if


### PR DESCRIPTION
It's is incorrect here, which can clearly be seen by expanding the contraction to "It is". Its is correct for possessive.